### PR TITLE
feat(auth): 페이지단 로그인 검증 로직 구현 및 404, 500페이지

### DIFF
--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Custom404 = () => {
+    return <h1>404 - Page Not Found</h1>;
+};
+
+export default Custom404;

--- a/src/pages/500.tsx
+++ b/src/pages/500.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Custom500 = () => {
+    return <h1>500 - Server-side error occurred</h1>;
+};
+
+export default Custom500;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,26 +1,38 @@
-import "@/styles/globals.css";
-import type { AppProps } from "next/app";
+import React from 'react';
+import '@/styles/globals.css';
+import type { AppProps } from 'next/app';
+import { useRouter } from 'next/router';
+import Cookies from 'js-cookie';
 
-import { QueryClient, QueryClientProvider } from "react-query";
-import { RecoilRoot } from "recoil";
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { RecoilRoot } from 'recoil';
 
-import "../assets/font/font.css";
+import '../assets/font/font.css';
 
 const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      retry: 0,
-    },
-  },
+    defaultOptions: {
+        queries: {
+            refetchOnWindowFocus: false,
+            retry: false
+        }
+    }
 });
 
 export default function App({ Component, pageProps }: AppProps) {
-  return (
-    <RecoilRoot>
-      <QueryClientProvider client={queryClient}>
-        <Component {...pageProps} />
-      </QueryClientProvider>
-    </RecoilRoot>
-  );
+    const router = useRouter();
+    const token = Cookies.get('accessToken');
+
+    React.useEffect(() => {
+        if (!token && (Component as any).requireAuth) {
+            router.push('/auth/signIn');
+        }
+    }, [router.pathname, token]);
+
+    return (
+        <RecoilRoot>
+            <QueryClientProvider client={queryClient}>
+                <Component {...pageProps} />
+            </QueryClientProvider>
+        </RecoilRoot>
+    );
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -23,7 +23,7 @@ export default function App({ Component, pageProps }: AppProps) {
     const token = Cookies.get('accessToken');
 
     React.useEffect(() => {
-        if (!token && (Component as any).requireAuth) {
+        if (!token && (Component as any).isRequireAuthPage) {
             router.push('/auth/signIn');
         }
     }, [router.pathname, token]);

--- a/src/pages/auth/signIn/SignIn.tsx
+++ b/src/pages/auth/signIn/SignIn.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useRouter } from 'next/router';
 
 import { css } from '@emotion/react';
@@ -39,7 +39,7 @@ const SignIn = () => {
         }
     };
 
-    useEffect(() => {
+    React.useEffect(() => {
         if (!!userData) {
             router.push('/main');
         }

--- a/src/pages/auth/signIn/SignIn.tsx
+++ b/src/pages/auth/signIn/SignIn.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useRouter } from 'next/router';
 
 import { css } from '@emotion/react';
@@ -17,6 +17,8 @@ const SignIn = () => {
     const router = useRouter();
 
     const { mutateAsync: authenticateUserMutate } = useUser.POST('signIn');
+
+    const { data: userData } = useUser.GET();
 
     const [loginData, setLoginData] = React.useState<IUserLogin>({
         email: '',
@@ -36,6 +38,12 @@ const SignIn = () => {
             // 추후 사용자에게 알리는 방식 구현
         }
     };
+
+    useEffect(() => {
+        if (!!userData) {
+            router.push('/main');
+        }
+    }, [router, userData]);
 
     return (
         <main>

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -28,6 +28,6 @@ const Main = () => {
     );
 };
 
-Main.requireAuth = true;
+Main.isRequireAuthPage = true;
 
 export default Main;

--- a/src/pages/main/Main.tsx
+++ b/src/pages/main/Main.tsx
@@ -2,8 +2,6 @@
 import React from 'react';
 import { css } from '@emotion/react';
 
-import useLoginStatus from '@/query-hooks/useUser';
-
 import { FlexContainer } from 'nimble-ds';
 
 import Navigation from './components/Navigation';
@@ -11,11 +9,6 @@ import MainContainer from './components/MainContainer';
 import CurrentTimeContainer from './components/CurrentTimeContainer';
 
 const Main = () => {
-    const { data: userData } = useLoginStatus.GET();
-
-    // test
-    console.log(userData);
-
     return (
         <main>
             <Navigation />
@@ -34,5 +27,7 @@ const Main = () => {
         </main>
     );
 };
+
+Main.requireAuth = true;
 
 export default Main;

--- a/src/pages/main/components/Navigation/Navigation.tsx
+++ b/src/pages/main/components/Navigation/Navigation.tsx
@@ -1,5 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
+import { useRouter } from 'next/router';
+
+import Cookies from 'js-cookie';
 import { css } from '@emotion/react';
 
 import { FlexContainer } from 'nimble-ds';
@@ -9,6 +12,13 @@ import { NAVIGATION_ITEMS } from './constants';
 import { navStyle } from './Navigation.style';
 
 const Navigation = () => {
+    const router = useRouter();
+
+    const logout = () => {
+        Cookies.remove('accessToken');
+        router.push('/auth/signIn');
+    };
+
     return (
         <nav css={css(navStyle)}>
             <FlexContainer
@@ -27,6 +37,7 @@ const Navigation = () => {
                         key={i}
                     />
                 ))}
+                <button onClick={logout}>Logout</button>
             </FlexContainer>
         </nav>
     );

--- a/src/query-hooks/useUser/GET/api.type.ts
+++ b/src/query-hooks/useUser/GET/api.type.ts
@@ -1,19 +1,15 @@
 // checkUserLoginStatus function Type
 export namespace CheckUserLoginStatus {
     export interface Response {
-        data: {
-            email: string;
-            nickname: string;
-            providerType: 'LOCAL' | 'GOOGLE' | 'KAKAO' | 'NAVER';
-        };
+        email: string;
+        nickname: string;
+        providerType: 'LOCAL' | 'GOOGLE' | 'KAKAO' | 'NAVER';
     }
 
     export interface Return {
-        data: {
-            email: string;
-            nickname: string;
-            providerType: 'LOCAL' | 'GOOGLE' | 'KAKAO' | 'NAVER';
-        };
+        email: string;
+        nickname: string;
+        providerType: 'LOCAL' | 'GOOGLE' | 'KAKAO' | 'NAVER';
     }
 
     export interface GetFunc {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,37 +1,25 @@
 {
-  "compilerOptions": {
-    "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "module": "esnext",
-    "moduleResolution": "node",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "jsx": "preserve",
-    "incremental": true,
-    "baseUrl": ".",
-    "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+    "compilerOptions": {
+        "target": "es5",
+        "lib": ["dom", "dom.iterable", "esnext"],
+        "allowJs": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "forceConsistentCasingInFileNames": true,
+        "noEmit": false,
+        "esModuleInterop": true,
+        "module": "esnext",
+        "moduleResolution": "node",
+        "resolveJsonModule": true,
+        "isolatedModules": true,
+        "jsx": "preserve",
+        "incremental": true,
+        "baseUrl": ".",
+        "paths": {
+            "@/*": ["./src/*"]
+        },
+        "jsxImportSource": "@emotion/react"
     },
-    "jsxImportSource": "@emotion/react"
-  },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+    "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+    "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- 로그인 검증이 필요한 페이지 및 Component에 사용할 수 있도록 _app.tsx를 수정했습니다.
    -  accessToken가 없고, Component.requireAuth가 true면 로그인 페이지로 이동하도록 구현하였습니다.
    

- 404, 500 페이지를 일부 구현하였습니다.
    - 추후 디자인에 따라 달라질 거니?!

