### PR TITLE
fix(Error): axios intersector에 401 에러 핸들 추가

### DIFF
--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -37,6 +37,10 @@ axiosInstance.interceptors.response.use(
     async (error: AxiosError) => {
         const originalRequest = error.config as InternalAxiosRequestConfig;
 
+        if (error.response?.status === 401) {
+            return { data: null };
+        }
+
         if (
             error.response?.status === 401 &&
             !originalRequest._retry &&


### PR DESCRIPTION
# Summary

- 401에러에 대한 처리를 했습니다.

# Description

- 서버에서 제공하는 401 에러는 메인페이지에서 상시 발생할 여력이 있습니다.
  - 비로그인일 때 미팅 조회
  - 로그인 환경 조회 등등

- 401일 때 401페이지로 이동함에 따라 정상 동작을 하지 않아 관련해 axios intersectors에 관련 코드를 추가했습니다.

### To Reviewers

-

### issue

- #63 
