### PR TITLE
feat(query): react-query 버전업 및 관리방식 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dependencies": {
         "@emotion/core": "^11.0.0",
         "@emotion/react": "^11.11.1",
+        "@tanstack/react-query": "^4.33.0",
         "@types/node": "18.14.2",
         "@types/react": "18.0.28",
         "@types/react-dom": "18.0.11",
@@ -29,7 +30,6 @@
         "react-hook-form": "^7.45.1",
         "react-hot-toast": "^2.4.1",
         "react-icons": "^4.8.0",
-        "react-query": "^3.39.3",
         "recoil": "^0.7.7",
         "ts-loader": "^9.4.4",
         "typescript": "^5.1.6"

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
         "typescript": "^5.1.6"
     },
     "devDependencies": {
+        "@tanstack/react-query-devtools": "^4.33.0",
         "@types/crypto-js": "^4.1.1",
         "@types/js-cookie": "^3.0.3",
         "babel-loader": "^9.1.3",
-        "cypress": "12.9.0",
-        "react-query-devtools": "^2.6.3"
+        "cypress": "12.9.0"
     }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,8 @@ import '@/styles/globals.css';
 
 import { Toaster } from 'react-hot-toast';
 import { ErrorBoundary } from '@/components/Error';
-import { QueryClient, QueryClientProvider } from 'react-query';
-import { ReactQueryDevtools } from 'react-query/devtools';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { RecoilRoot } from 'recoil';
 
 import '../assets/font/font.css';
@@ -30,15 +30,15 @@ export default function RootLayout({
         <html>
             <head />
             <body>
-                <RecoilRoot>
-                    <QueryClientProvider client={queryClient}>
+                <QueryClientProvider client={queryClient}>
+                    <RecoilRoot>
                         <ErrorBoundary>
                             {children}
                             <Toaster />
                         </ErrorBoundary>
                         <ReactQueryDevtools initialIsOpen={false} />
-                    </QueryClientProvider>
-                </RecoilRoot>
+                    </RecoilRoot>
+                </QueryClientProvider>
             </body>
         </html>
     );

--- a/src/components/Main/MeetingDashboard/MeetingDashboard.tsx
+++ b/src/components/Main/MeetingDashboard/MeetingDashboard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 // react-query
-import { useGetMeet } from '@/query-hooks/useMeet';
+import { useQuery } from '@tanstack/react-query';
+import { fetchMeet } from '@/query-hooks/useMeet';
 
 // components
 import { FlexContainer, Typography } from 'nimble-ds';
@@ -15,7 +16,7 @@ import {
 } from './MeetingDashboard.style';
 
 const MeetingDashboard = () => {
-    const { data: meetings } = useGetMeet();
+    const { data: meetings } = useQuery(fetchMeet());
 
     return (
         <FlexContainer direction="column" customCss={layoutStyle}>

--- a/src/components/Main/PeopleSearchBox/PeopleSearchBox.tsx
+++ b/src/components/Main/PeopleSearchBox/PeopleSearchBox.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 
 // react-query
-import { useInviteMeet, useGetSpecificMeet } from '@/query-hooks/useMeet';
+import { useQuery } from '@tanstack/react-query';
+import { useInviteMeet, fetchSpecificMeet } from '@/query-hooks/useMeet';
+
 // hooks
 import useOnClickOutside from '@/hooks/useOnClickOutside';
 
@@ -18,7 +20,7 @@ interface Props {
 
 const PeopleSearchBox = ({ meetingId, setIsSearchBoxOpen }: Props) => {
     const [userEmail, setUserEmail] = React.useState('');
-    const { data } = useGetSpecificMeet(meetingId);
+    const { data } = useQuery(fetchSpecificMeet(meetingId));
     const { mutateAsync: inviteMeetMutate, isLoading } = useInviteMeet();
 
     const changeUserEmail = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -4,7 +4,11 @@ import axios, {
     AxiosRequestConfig,
     AxiosResponse
 } from 'axios';
+
 import Cookies from 'js-cookie';
+
+import { handleError } from '@/utils/Error/handleError';
+import { ERROR_CODE } from '@/constants/error';
 
 interface InternalAxiosRequestConfig<T = any> extends AxiosRequestConfig {
     _retry?: boolean;
@@ -37,12 +41,13 @@ axiosInstance.interceptors.response.use(
     async (error: AxiosError) => {
         const originalRequest = error.config as InternalAxiosRequestConfig;
 
-        if (error.response?.status === 401) {
+        if (error.response?.status === ERROR_CODE.UNAUTHORIZED) {
+            handleError(error, ERROR_CODE.UNAUTHORIZED);
             return { data: null };
         }
 
         if (
-            error.response?.status === 401 &&
+            error.response?.status === ERROR_CODE.UNAUTHORIZED &&
             !originalRequest._retry &&
             originalRequest.url !== '/auth/refresh'
         ) {

--- a/src/lib/axiosInstance.ts
+++ b/src/lib/axiosInstance.ts
@@ -37,6 +37,10 @@ axiosInstance.interceptors.response.use(
     async (error: AxiosError) => {
         const originalRequest = error.config as InternalAxiosRequestConfig;
 
+        if (error.response?.status === 401) {
+            return { data: null };
+        }
+
         if (
             error.response?.status === 401 &&
             !originalRequest._retry &&

--- a/src/query-hooks/useAuth/index.ts
+++ b/src/query-hooks/useAuth/index.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios';
-import { useMutation } from 'react-query';
+import { useMutation } from '@tanstack/react-query';
 
 // apis
 import { postAuthenticateUser, postLogoutUser } from './api';

--- a/src/query-hooks/useMeet/index.ts
+++ b/src/query-hooks/useMeet/index.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios';
-import { useQuery, useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 // apis
 import {
@@ -16,35 +16,32 @@ import { meetKey } from './key';
 // lib utils
 import renderToast from '@/lib/toast';
 
-import type { Post, Get } from './api.type';
+import type { Post } from './api.type';
 
 // [GET] 본인에게 해당되는 meeting 목록을 가져옴
-const useGetMeet = () =>
-    useQuery<Get.All.Return>(meetKey.all(), getMeet, {
-        onError: () => {
-            renderToast({
-                type: 'error',
-                message:
-                    '미팅 목록을 가져오는데 실패했습니다. 다시 시도해주세요.'
-            });
-        }
-    });
+const fetchMeet = () => ({
+    queryKey: meetKey.all(),
+    queryFn: () => getMeet(),
+    onError: () => {
+        renderToast({
+            type: 'error',
+            message: '미팅 목록을 가져오는데 실패했습니다. 다시 시도해주세요.'
+        });
+    }
+});
 
 // [GET] 특정 meeting 정보를 가져옴
-const useGetSpecificMeet = (meetingId: number) =>
-    useQuery<Get.Specific.Return>(
-        meetKey.specificMeet(meetingId),
-        () => getSpecificMeet({ meetingId }),
-        {
-            onError: () => {
-                renderToast({
-                    type: 'error',
-                    message:
-                        '특정 미팅 정보를 가져오는데 실패했습니다. 다시 시도해주세요.'
-                });
-            }
-        }
-    );
+const fetchSpecificMeet = (meetingId: number) => ({
+    queryKey: meetKey.specificMeet(meetingId),
+    queryFn: () => getSpecificMeet({ meetingId }),
+    onError: () => {
+        renderToast({
+            type: 'error',
+            message:
+                '특정 미팅 정보를 가져오는데 실패했습니다. 다시 시도해주세요.'
+        });
+    }
+});
 
 // [POST] 새로운 meeting을 만듦
 const usePostMeet = () => {
@@ -112,8 +109,8 @@ const useKickOutMeet = () => {
 };
 
 export {
-    useGetMeet,
-    useGetSpecificMeet,
+    fetchMeet,
+    fetchSpecificMeet,
     usePostMeet,
     useInviteMeet,
     useKickOutMeet

--- a/src/query-hooks/useUser/index.ts
+++ b/src/query-hooks/useUser/index.ts
@@ -1,5 +1,5 @@
 import { AxiosError } from 'axios';
-import { useQuery, useMutation } from 'react-query';
+import { useMutation } from '@tanstack/react-query';
 
 // apis
 import { getUserInfo, checkLoginStatus, createNewUser } from './api';
@@ -15,35 +15,32 @@ import renderToast from '@/lib/toast';
 // error code constants
 import { ERROR_CODE } from '@/constants/error';
 
-import type { Get, Post } from './api.type';
+import type { Post } from './api.type';
 
 // [GET] 특정 사용자의 정보를 가져옴
-const useGetUserInfo = (email: string) =>
-    useQuery<Get.UserInfo.Return>(
-        userKey.info(email),
-        () => getUserInfo({ email }),
-        {
-            onError: () => {
-                renderToast({
-                    type: 'error',
-                    message:
-                        '사용자의 정보를 가져오는데 실패했습니다. 다시 시도해주세요.'
-                });
-            }
-        }
-    );
+const fetchUserInfo = (email: string) => ({
+    queryKey: userKey.info(email),
+    queryFn: () => getUserInfo({ email }),
+    onError: () => {
+        renderToast({
+            type: 'error',
+            message:
+                '사용자의 정보를 가져오는데 실패했습니다. 다시 시도해주세요.'
+        });
+    }
+});
 
 // [GET] 로그인 상태를 확인함
-const useFetchLoginStatus = () =>
-    useQuery<Get.CheckUser.Return>(userKey.all(), checkLoginStatus, {
-        onError: () => {
-            renderToast({
-                type: 'error',
-                message:
-                    '로그인 상태를 확인하는데 실패했습니다. 다시 시도해주세요.'
-            });
-        }
-    });
+const fetchLoginStatus = () => ({
+    queryKey: userKey.all(),
+    queryFn: () => checkLoginStatus(),
+    onError: () => {
+        renderToast({
+            type: 'error',
+            message: '로그인 상태를 확인하는데 실패했습니다. 다시 시도해주세요.'
+        });
+    }
+});
 
 // [POST] 새로운 사용자를 만듦
 const useCreateNewUser = () => {
@@ -61,4 +58,4 @@ const useCreateNewUser = () => {
     );
 };
 
-export { useGetUserInfo, useFetchLoginStatus, useCreateNewUser };
+export { fetchUserInfo, fetchLoginStatus, useCreateNewUser };

--- a/src/view/main/index.tsx
+++ b/src/view/main/index.tsx
@@ -3,7 +3,8 @@ import React from 'react';
 import { css } from '@emotion/react';
 
 // react-query
-import { useFetchLoginStatus } from '@/query-hooks/useUser';
+import { useQuery } from '@tanstack/react-query';
+import { fetchLoginStatus } from '@/query-hooks/useUser';
 
 // components
 import { FlexContainer } from 'nimble-ds';
@@ -25,7 +26,7 @@ import {
 } from './main.style';
 
 const Main = () => {
-    const { data: userData } = useFetchLoginStatus();
+    const { data: userData } = useQuery(fetchLoginStatus());
 
     return (
         <main css={css(layoutStyle)}>


### PR DESCRIPTION
# Summary

- react-query 관리 방식을 변경합니다.
- react-query 버전 업
- axiosinstance intersector에서 401 에러에 대한 토스트 메시지 제공

# Description

기존 query-hooks의 로직에서 useQuery를 리턴하지만, 
Suspense로 감싸진 하나의 컴포넌트에 여러개의 useQuery가 있으면 네트워크 병목 현상이 발생하는 문제가 있습니다
- 이유: Suspense가 비동기를 만날때마다 fallback으로 전환되며 생기는 문제
- 이를 해결하기 위해 useQuery를 return하는 게 아닌 useQuery 내부에 들어가는 queryKey와 queryFn을 가진 객체를 return합니다.

### 사용법
- useQuery를 컴포넌트에서 import해서 사용합니다.
- 하나의 컴포넌트에 여러 개의 useQuery가 필요한 경우 queryKey와 queryFn을 가진 fetch 함수를 가져와 useQueries로 쉽게 매핑할 수 있습니다.

### To Reviewers

- 화이팅~

### issue

- #62 
